### PR TITLE
Add .gitattributes for syntax highlighting of *.bm files on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bm linguist-language=Rust


### PR DESCRIPTION
Using [test.bm](https://github.com/repnop/bismite/blob/master/test.bm) as the example (with github dark userstyle)

Before:
![image](https://user-images.githubusercontent.com/6868531/101294978-b4c9da80-37e8-11eb-8201-26fc5db71f4f.png)

After:
![image](https://user-images.githubusercontent.com/6868531/101295003-dd51d480-37e8-11eb-9bdd-9bab8eabe3fb.png)
